### PR TITLE
OS-1866 PATCH: Reverted anchor-based section links in edit mode to re…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -455,8 +455,8 @@ class format_grid extends core_courseformat\base {
      * @return null|moodle_url
      */
     public function get_view_url($section, $options = []) {
-        global $PAGE;
         $course = $this->get_course();
+        $url = new moodle_url('/course/view.php', ['id' => $course->id]);
 
         if (array_key_exists('sr', $options)) {
             $sectionno = $options['sr'];
@@ -465,17 +465,25 @@ class format_grid extends core_courseformat\base {
         } else {
             $sectionno = $section;
         }
-
-        $context = context_course::instance($course->id);
-        if (!($PAGE->user_is_editing() && has_capability('moodle/course:update', $context))) {
-            if (!empty($options['navigation']) && $sectionno !== null) {
-                // Display section on separate page when not editing.
-                $sectioninfo = $this->get_section($sectionno);
-                return new moodle_url('/course/section.php', ['id' => $sectioninfo->id]);
-            }
+        
+        /**
+         * OS-1866 PATCH: Reverted anchor-based section links in edit mode
+         * to restore breadcrumbs to section.php edit mode.
+         * - Partial revert to e8dfb802ddf2cad2ee47f38af60fbd83bacbe0dd
+         * from 0a4b9a1c31a2c31bdea75e3212fae207603c69d8
+         *
+         * Original logic returned view.php#section-N when editing, which 
+         * broke breadcrumbs on section.php (active node mismatch)
+         *
+         * This patch restores section.php links for navigation intent,
+         * while preserving anchors for general links.
+         *
+         */
+        if (!empty($options['navigation']) && $sectionno !== null) {
+            // Display section on separate page.
+            $sectioninfo = $this->get_section($sectionno);
+            return new moodle_url('/course/section.php', ['id' => $sectioninfo->id]);
         }
-
-        $url = new moodle_url('/course/view.php', ['id' => $course->id]);
         if ($this->uses_sections() && $sectionno !== null) {
             $url->set_anchor('section-'.$sectionno);
         }


### PR DESCRIPTION
…store breadcrumbs to section.php edit mode.

- Partial revert to e8dfb802ddf2cad2ee47f38af60fbd83bacbe0dd from 0a4b9a1c31a2c31bdea75e3212fae207603c69d8

Original logic returned `view.php#section-N` when editing, which broke breadcrumbs on section.php (active node mismatch)

This patch restores section.php links for navigation intent, while preserving anchors for general links.